### PR TITLE
Strings are just lists of characters

### DIFF
--- a/lustc/examples/format.lisp
+++ b/lustc/examples/format.lisp
@@ -1,0 +1,132 @@
+(let #t (eq 1 1))
+(let #f (eq 0 1))
+
+(let list (fn (& args) args))
+(let last (fn (list)
+	      (if (eq list ())
+		  ()
+		  (if (eq (cdr list) ())
+		      (car list)
+		      (last (cdr list))))))
+
+(let do (fn (& args)
+	    (last args)))
+
+
+(let and (fn (a b)
+	      (if a (if b #t #f) #f)))
+
+(let len (fn (list)
+	     (if (eq list ())
+		 0
+		 (add 1 (len (cdr list))))))
+
+(let list-starts-with (fn (list pred)
+			  (if (and (null? list) (not (null? pred))) #f
+			      (if (eq pred ()) #t
+				  (if (not (eq (car pred) (car list))) #f
+				      (if (gt (len pred) (len list)) #f
+					  (list-starts-with (cdr list) (cdr pred))))))))
+
+(let remove-n (fn (list n)
+		  (if (null? list) ()
+		      (if (eq n 0) list
+			  (remove-n (cdr list) (sub n 1))))))
+
+(let split-until (fn (lst wedge)
+		     (if (not (null? lst))
+			 (if (list-starts-with lst wedge)
+			     (list () (remove-n lst (len wedge)))
+			     (do
+			      (let res (split-until (cdr lst) wedge))
+			      (if (null? res)
+				  (list lst ())
+				  (list (cons (car lst) (car res)) (car (cdr res))))))
+			 ())))
+
+(let split (fn (lst wedge)
+	       (if (not (null? lst))
+		   (do
+		    (let res (split-until lst wedge))
+		    (let start (car res))
+		    (let rest (car (cdr res)))
+		    (cons start (split rest wedge)))
+		   ())))
+
+(let append (fn (lst item)
+		(if (null? lst)
+		    (list item)
+		    (cons (car lst) (append (cdr lst) item)))))
+
+(let concat (fn (lst tail)
+		(if (null? tail)
+		    lst
+		    (concat (append lst (car tail)) (cdr tail)))))
+
+(let list-kinda-eq (fn (a b)
+		 (if (not (eq (len a) (len b))) #f
+		     (do
+		      (let helper (fn (a b)
+				      (if (null? a) #t
+					  (if (eq (car a) (car b))
+					      (helper (cdr a) (cdr b))
+					      #f))))
+		      (helper a b)))))
+
+;; Without an apply primitive we can't use sprintf here.
+(let printf (fn (lst & args)
+		 (if (not (null? lst))
+		   (do
+		    (let sections (split lst "{}"))
+		    (let helper (fn (split args)
+				    (if (not (null? split))
+					(do
+					 (let split-next (if (not (null? split))
+					     (do
+					      (let s (car split))
+					      (print s)
+					      (cdr split))
+					     ()))
+					 (let args-next (if (not (null? args))
+					     (do
+					      (let a (car args))
+					      (print a)
+					      (cdr args))
+					     ()))
+					 (helper split-next args-next))
+				       ())))
+		    (helper sections args)
+		    (print "\n"))
+		   ())))
+
+(let sprintf (fn (lst & args)
+		 (if (not (null? lst))
+		   (do
+		    (let res ())
+		    (let sections (split lst "{}"))
+		    (let helper (fn (split args)
+				    (if (not (null? split))
+					(do
+					 (let split-next (if (not (null? split))
+					     (do
+					      (let s (car split))
+					      (set res (concat res s))
+					      (cdr split))
+					     ()))
+					 (let args-next (if (not (null? args))
+					     (do
+					      (let a (car args))
+					      (set res (concat res a))
+					      (cdr args))
+					     ()))
+					 (helper split-next args-next))
+				       ())))
+		    (helper sections args)
+		    res)
+		   ())))
+
+(println (sprintf "hello {} {}!" "zeke" "medley"))
+(printf "hello {}!" "zeke")
+
+;; This line just exists so that we can test these functions.
+(list-kinda-eq (sprintf "hello there {}! your lucky number is {} :)" "zeke" "10") "hello there zeke! your lucky number is 10 :)")

--- a/lustc/examples/hello-world.lisp
+++ b/lustc/examples/hello-world.lisp
@@ -1,1 +1,3 @@
-(foreign-call "puts" "hello world!")
+(print "hello world!\n")
+
+(println (car "hello world"))

--- a/lustc/src/compiler.rs
+++ b/lustc/src/compiler.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use crate::conditional;
-use crate::conversions::print_lustc_word;
+use crate::conversions::{print_lustc_word, println_lustc_word};
 use crate::data;
 use crate::escape;
 use crate::fatal;
@@ -71,6 +71,8 @@ impl Default for JIT {
         // Register the print function.
         let print_addr = print_lustc_word as *const u8;
         builder.symbol("print_lustc_word", print_addr);
+        let println_addr = println_lustc_word as *const u8;
+        builder.symbol("println_lustc_word", println_addr);
 
         let module = JITModule::new(builder);
         let mut jit = Self {

--- a/lustc/src/fatal.rs
+++ b/lustc/src/fatal.rs
@@ -41,7 +41,9 @@ pub(crate) fn emit_error_strings(jit: &mut JIT) -> Result<(), String> {
         .map(|(name, msg)| -> Result<LustData, std::ffi::NulError> {
             Ok(LustData {
                 name: name.to_string(),
-                data: crate::conversions::string_to_immediate(&std::ffi::CString::new(*msg)?),
+                // bit of a hack but we tag these as pairs so that
+                // they register as heap allocated values elsewhere.
+                data: std::ffi::CString::new(*msg)?.into_raw() as Word | conversions::PAIR_TAG,
             })
         })
         .collect::<Result<Vec<LustData>, _>>()

--- a/lustc/src/foreign.rs
+++ b/lustc/src/foreign.rs
@@ -14,7 +14,7 @@ impl Expr {
             if let Some(Expr::Symbol(s)) = v.first() {
                 if s == "foreign-call" && v.len() >= 2 {
                     if let Expr::String(name) = &v[1] {
-                        return Some((name.clone().into_string().unwrap(), &v[2..]));
+                        return Some((name.clone(), &v[2..]));
                     }
                 }
             }
@@ -27,7 +27,7 @@ impl Expr {
             if let Some(Expr::Symbol(s)) = v.first() {
                 if s == "foreign-call" && v.len() >= 2 {
                     if let Expr::String(name) = &v[1] {
-                        return Some((name.clone().into_string().unwrap(), &mut v[2..]));
+                        return Some((name.clone(), &mut v[2..]));
                     }
                 }
             }
@@ -169,52 +169,4 @@ pub(crate) fn emit_untag(expr: &Expr, ctx: &mut Context) -> Result<Value, String
 
     let arg = ctx.builder.block_params(return_block)[0];
     Ok(arg)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::ffi::CString;
-
-    use crate::roundtrip_string;
-
-    use super::*;
-
-    #[test]
-    fn puts() {
-        let source = r#"
-(let res (foreign-call "puts" "test of puts"))
-"#;
-        let res = roundtrip_string(source).unwrap();
-        match res {
-            Expr::Integer(i) => assert!(i >= 0),
-            _ => panic!("expected fixnum"),
-        }
-    }
-
-    #[test]
-    fn strlen() {
-        let source = r#"
-(let res (foreign-call "strlen" "four"))
-"#;
-        let res = roundtrip_string(source).unwrap();
-        match res {
-            Expr::Integer(i) => assert_eq!(i, 4),
-            _ => panic!("expected fixnum"),
-        }
-    }
-
-    #[test]
-    fn open_read() {
-        let source = r#"
-(let fd (foreign-call "open" "examples/file.lisp" 0))
-(let bar "hello there")
-(foreign-call "read" fd bar 11)
-bar
-"#;
-        let res = roundtrip_string(source).unwrap();
-        let file = std::fs::read_to_string("examples/file.lisp").unwrap();
-        let expected = &file[0..11];
-        let expected = CString::new(expected).unwrap();
-        assert_eq!(res, Expr::String(expected))
-    }
 }

--- a/lustc/src/lib.rs
+++ b/lustc/src/lib.rs
@@ -34,7 +34,7 @@ pub enum Expr {
     Nil,
     List(Vec<Expr>),
     Symbol(String),
-    String(std::ffi::CString),
+    String(String),
 }
 
 impl crate::parser::Expr {
@@ -55,9 +55,7 @@ impl crate::parser::Expr {
                     )
                 }
             }
-            ExprVal::String(s) => Expr::String(
-                std::ffi::CString::new(s).map_err(|e| format!("unsupported string: {} ", e))?,
-            ),
+            ExprVal::String(s) => Expr::String(s),
         })
     }
 }

--- a/lustc/src/procedures.rs
+++ b/lustc/src/procedures.rs
@@ -282,11 +282,12 @@ pub struct LustFn {
 }
 
 fn is_varadic_param(p: &str) -> bool {
-    p.len() == 3 && p.chars().last() == Some('&')
+    p.chars().last() == Some('&')
 }
 
 fn is_varadic_signature(sig: &[&String]) -> bool {
-    sig.iter().any(|p| is_varadic_param(p))
+    let varadic = sig.iter().any(|p| is_varadic_param(p));
+    varadic
 }
 
 fn get_and_validate_varadic(sig: &[&String]) -> Result<String, String> {
@@ -724,6 +725,12 @@ mod tests {
     fn do_impl() {
         let res = roundtrip_file("examples/do.lisp").unwrap();
         assert_eq!(res, Expr::Integer(11))
+    }
+
+    #[test]
+    fn printf_impl() {
+        let res = roundtrip_file("examples/format.lisp").unwrap();
+        assert_eq!(res, Expr::Bool(true))
     }
 
     #[test]


### PR DESCRIPTION
Previously strings were c strings. This was nice for making foreign
calls but makes strings a whole new language feature that needs to be
learned. Instead we now treat strings as regular lists of characters.

This commit also adds a printf function which works the way you'd
expect it to using format strings from rust. For example
`(printf "hello {}" "zeke")` prints "hello zeke".

This is a very exciting milestone because a printf function was the
last thing we wrote in the interpreter before moving on to the
compiler. Outside of memory management the compiler is now very close
to feature parity with the interpreter!